### PR TITLE
Restrict namespace bindings

### DIFF
--- a/gremlin/config.py
+++ b/gremlin/config.py
@@ -8,7 +8,9 @@ DEFAULT_CONFIG = {
     'response_timeout': None,
     'ssl_context': None,
     'uri': 'ws://localhost:8182/gremlin',
-    'username': ''
+    'username': '',
+    'use_local_namespace': True,
+    'warnings': False
 }
 
 

--- a/gremlin/magic.py
+++ b/gremlin/magic.py
@@ -124,14 +124,27 @@ class GremlinMagic(Magics):
 
     @line_magic('gremlin.clean_bindings')
     def clean_bindings(self, line):
+        """Clean all registered bindings."""
         self.bindings = set()
 
     @line_magic('gremlin.register_binding')
     def register_binding(self, binding: str):
+        """Register namespace variable as gremlin binding.
+
+        Example: `%gremlin.register_binding foo` where `foo` is
+        name of our variable, ie. foo = 'vertex_id'.
+
+        Note: Binding value has to be JSON serializable.
+        """
         self.bindings.add(binding)
 
     @line_magic('gremlin.register_namespace')
     def register_namespace(self, params=''):
+        """Register the whole namespace.
+
+        Note: private variables (ie. underscored variables)
+        have to be registered explicitly by `register_binding`.
+        """
         parser = argparse.ArgumentParser()
         parser.add_argument('--allow-private', action='store_true',
                             help="Whether to include private variables.")
@@ -145,10 +158,12 @@ class GremlinMagic(Magics):
 
     @line_magic('gremlin.remove_binding')
     def remove_binding(self, key: str):
+        """Remove registered binding."""
         self.bindings.remove(key)
 
     @line_magic('gremlin.get_bindings')
     def get_bindings(self, line):
+        """Get set of registered bindings."""
         bindings = self.bindings
 
         if self.use_local_namespace:

--- a/gremlin/utils.py
+++ b/gremlin/utils.py
@@ -21,6 +21,7 @@ def parse(connection_str):
 
 
 def sanitize_namespace(user_ns, bindings=None, allow_private=False):
+    """Filter namespace."""
     bindings = bindings or dict()
     namespace = dict()
 

--- a/gremlin/utils.py
+++ b/gremlin/utils.py
@@ -2,9 +2,13 @@
 import asyncio
 import json
 import re
+import sys
 
 from gremlin_python.driver import request
-from gremlin import registry, resultset
+from gremlin import config, registry, resultset
+
+
+_IPYTHON_VARS = {'In', 'Out'}
 
 
 def parse(connection_str):
@@ -16,29 +20,45 @@ def parse(connection_str):
     return descriptors
 
 
-def _sanitize_namespace(user_ns):
-    bindings = {}
+def sanitize_namespace(user_ns, bindings=None, allow_private=False):
+    bindings = bindings or dict()
+    namespace = dict()
+
     for k, v in user_ns.items():
+
         try:
             json.dumps(v)
-        except:
-            pass
-        else:
-            bindings[k] = v
-    return bindings
+        except Exception as exc:
+            if config.defaults.warnings:
+                print("[WARNING] Serialization of object `{obj}` failed. Skipping.".format(obj=k),
+                      exc, file=sys.stderr)
+            continue
+
+        # pop ipython vars (if they are not overridden by user)
+        if k in _IPYTHON_VARS and k not in bindings:
+            continue
+
+        if k.startswith('_') and not allow_private:
+            if k in bindings:
+                namespace[k] = v
+            else:
+                continue
+
+        namespace[k] = v
+
+    return namespace
 
 
-def submit(gremlin, user_ns, aliases, conn):
+def submit(gremlin, conn, bindings, aliases):
     """
     Submit a script to the Gremlin Server using the IPython namespace
     using the IPython namespace to pass bindings using Magics configuration
     and a connection registered with
     :py:class:`ConnectionRegistry<gremlin.registry.ConnectionRegistry>`
     """
-    bindings = _sanitize_namespace(user_ns)
     message = request.RequestMessage(
         processor='', op='eval',
-        args={'gremlin': gremlin, 'aliases': aliases, 'bindings': bindings})
+        args={'gremlin': gremlin, 'aliases': aliases, 'bindings': sanitize_namespace(bindings)})
     return asyncio.run_coroutine_threadsafe(_submit(conn, message), registry.LOOP).result()
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-aiogremlin==3.2.4
-ipython==5.3.0
+aiogremlin==3.2.6rc1
+ipython

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,7 @@
 from setuptools import setup
 
+with open("requirements.txt", 'r') as f:
+    REQUIREMENTS = f.readlines()
 
 setup(
     name="ipython-gremlin",
@@ -11,10 +13,7 @@ setup(
     description="Runs scripts agains the Gremlin Server from IPython",
     long_description=open("README.txt").read(),
     packages=["gremlin"],
-    install_requires=[
-        "aiogremlin>=3.2.6",
-        "ipython>=5.3.0"
-    ],
+    install_requires=REQUIREMENTS,
     test_suite="tests",
     classifiers=[
         'Development Status :: 3 - Alpha',


### PR DESCRIPTION
Restrict namespace bindings to prevent [eval] error and to lower serialization overhead.

This PR introduces new magic commands which allow handling of the
IPython namespace such that minimal amount of unnecessary bindings is
sent over to gremlin. (see issue #1)

New magic commands:
```
%clean_bindings
%register_binding
%register_namespace
%remove_binding
%get_bindings
```
Also, config.py has been modified, the default behaviour does pass the
namespace by default, however, sanitization of the namespace has been
improved. This behaviour can be configured by `use_local_namespace`
config variable.

Example (given that loading local namespace is disabled):

```python
%load_ext gremlin  # as usual
```

```python
g = ...  # gremlin graph object
vertex_id = '123456'  # vertex id to be passed as binding to the gremlin
```

```python
%gremlin.register_binding vertex_id
```